### PR TITLE
Locking library versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 from setup_common import setup_options
 
 setup(extras_require={
-    'pyqt5': ['pyqt5']
+    'pyqt5': ['pyqt5==5.10']
 },
     zip_safe=False,
     **setup_options)

--- a/setup_common.py
+++ b/setup_common.py
@@ -9,5 +9,5 @@ setup_options = {
     "author": 'Bitcraze',
     "author_email": 'contact@bitcraze.io',
     "license": 'MIT',
-    "install_requires": ["pyusb", "pyserial"],
+    "install_requires": ["pyusb==1.0.2", "pyserial==3.4"],
 }


### PR DESCRIPTION
## Problem
**System:** Ubuntu 16.04
**Python:** 3.5.2

Having followed the installation instructions I get the following problem:
```
$ python3 -m lpstools

Error:
Traceback (most recent call last):
  File "/usr/lib/python3.5/runpy.py", line 184, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.5/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/user/Dokument/lps-tools/lpstools/__main__.py", line 1, in <module>
    from lpstools.gui import main
  File "/home/user/Dokument/lps-tools/lpstools/gui.py", line 7, in <module>
    from PyQt5 import QtCore
ImportError: /home/user/Dokument/lps-tools/venv/lib/python3.5/site-packages/PyQt5/QtCore.so: undefined symbol: PySlice_AdjustIndices
```

## Steps to reproduce:
```sh
$ git clone https://github.com/bitcraze/lps-tools.git
$ cd lps-tools/
$ virtualenv -p python3 venv
$ source venv/bin/activate
$ pip3 install -e .[pyqt5]
$ pip3 install -e .
$ python3 -m lpstools
```

## Tests: 
```sh
user@computer:~/Dokument/lps-tools$ tb build
Running build script tools/build/build in a container based on the bitcraze/builder:19 docker image as uid 388425
autopep8 wrapper.........................................................Passed
Check for added large files..............................................Passed
Check for case conflicts.................................................Passed
Check docstring is first.................................................Passed
Check JSON...............................................................Passed
Check for merge conflicts................................................Passed
Check Xml............................................(no files to check)Skipped
Check Yaml...............................................................Passed
Debug Statements (Python)................................................Passed
Detect Private Key.......................................................Passed
Fix End of Files.........................................................Passed
Flake8...................................................................Passed
Fix requirements.txt.....................................................Passed
Reorder python imports...................................................Passed
verify pass
.....
----------------------------------------------------------------------
Ran 5 tests in 0.166s

OK
Unit tests pass
```

**Note:** Only tested on Ubuntu 16.04. I suggest testing on Windows and OSX before merge so that there's problem with PyQt version 5.10 there.

## Solution:
Downgrade PyQt5 to version 5.10 in the wait for a proper fix. I suggest locking the version for other dependencies as well to avoid this problem in the future. 