### PR TITLE
Use int for progress bars

### DIFF
--- a/lpstools/gui.py
+++ b/lpstools/gui.py
@@ -133,7 +133,7 @@ class LpsToolsGui(QtWidgets.QMainWindow):
         self.state = STATE_DFU_DONE
 
     def _programming_progress(self, str, progress):
-        self.dfu_progress.setValue(progress * 100)
+        self.dfu_progress.setValue(int(progress * 100))
 
     def _config_done(self):
         self.cfg_progress.setValue(100)
@@ -141,7 +141,7 @@ class LpsToolsGui(QtWidgets.QMainWindow):
 
     def _config_progress(self, progress):
         self.cfg_progress.setFormat("%p%")
-        self.cfg_progress.setValue(progress * 100)
+        self.cfg_progress.setValue(int(progress * 100))
 
     # UI State handling
 


### PR DESCRIPTION
It has been reported that flashing of anchors fails on some systems.

It seems as progress bars now need an int when setting the value, while currently a float might be used instead. 

Confirmed with 
python 3.10.2
PyQt5                  5.15.6
PyQt5-Qt5              5.15.2
PyQt5-sip              12.10.1

